### PR TITLE
phpcs-lunr: Add setup steps for coding standard and add full report

### DIFF
--- a/.github/workflows/phpcs-lunr.yml
+++ b/.github/workflows/phpcs-lunr.yml
@@ -39,8 +39,15 @@ jobs:
             repository: 'lunr-php/lunr-coding-standard'
             ref: ${{ inputs.codestyle-branch }}
 
+            # Clone submodules recursively. `true` should be enough, but better be safe
+            submodules: 'recursive'
+
             # Relative path under $GITHUB_WORKSPACE to place the repository
             path: 'codestyle'
+
+      - name: Install dependencies
+        working-directory: 'codestyle'
+        run: composer install
 
       - name: Setup PHPCS
         uses: shivammathur/setup-php@v2
@@ -50,7 +57,15 @@ jobs:
 
       - name: Run PHPCS
         run: |
-          phpcs -q --report=checkstyle \
-                   --standard=$GITHUB_WORKSPACE/codestyle/Lunr \
-                   ${{ inputs.phpcs-whitelist }} \
-                   src/ | cs2pr
+          phpcs --report-full \
+                --report-checkstyle=checkstyle.xml \
+                --runtime-set installed_paths $GITHUB_WORKSPACE/codestyle/third-party/slevomat/ \
+                --bootstrap=$GITHUB_WORKSPACE/codestyle/bootstrap.php \
+                --standard=$GITHUB_WORKSPACE/codestyle/Lunr \
+                ${{ inputs.phpcs-whitelist }} \
+                src/
+
+      - name: Convert checkstyle output to github style
+        if: always()
+        run: cat ./checkstyle.xml | cs2pr
+


### PR DESCRIPTION
- Add setup steps for submodules and dependencies of the coding standard
- Add full report output since that is way more readable than the cs2pr output

Successful example run: https://github.com/pprkut/lunr.vortex/actions/runs/10281310239/job/28450589100
Example error run: https://github.com/pprkut/lunr.vortex/actions/runs/10281496751/job/28451180081